### PR TITLE
proper lineref in weblink that can be directly followed

### DIFF
--- a/internal/validate.go
+++ b/internal/validate.go
@@ -182,7 +182,7 @@ func validateWebUrls(w io.Writer, urls [][]string, filePath string, lineNum int,
 		url := link[2]
 
 		if !onlyErrors {
-			fmt.Fprintf(w, "open %s # filepath: %s linenumber: %d\n", url, filePath, lineNum)
+			fmt.Fprintf(w, "open %s # filepath: %s:%d\n", url, filePath, lineNum)
 		}
 	}
 	return 0


### PR DESCRIPTION
fixining issue in weblink comments